### PR TITLE
CP-1436 Document editorial V3 articles API

### DIFF
--- a/_includes/themes/twitter/api-doc-submenu.html
+++ b/_includes/themes/twitter/api-doc-submenu.html
@@ -5,7 +5,7 @@
 		{% for number in (1..4) %}
 			{% for p in site.pages %}
 			
-				{% if p.title-endpoint == page.title-endpoint and p.spec == page.spec %}
+				{% if p.title-endpoint == page.title-endpoint and p.spec == page.spec and p.version == page.version %}
 				
 						{% if p.number == number %}
 							<li {% if p.url == page.url %} class="active"{% endif %}>

--- a/api-documentation/editorial/articles/v2/01_make_overview/api-description.md
+++ b/api-documentation/editorial/articles/v2/01_make_overview/api-description.md
@@ -4,7 +4,7 @@ title : 'Get make overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get make overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/01_make_overview/api-parameters.md
+++ b/api-documentation/editorial/articles/v2/01_make_overview/api-parameters.md
@@ -4,7 +4,7 @@ title : 'Get make overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get make overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/01_make_overview/api-request.md
+++ b/api-documentation/editorial/articles/v2/01_make_overview/api-request.md
@@ -4,7 +4,7 @@ title : 'Get make overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get make overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/01_make_overview/api-response.md
+++ b/api-documentation/editorial/articles/v2/01_make_overview/api-response.md
@@ -4,7 +4,7 @@ title : 'Get make overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get make overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/02_model_overview/api-description.md
+++ b/api-documentation/editorial/articles/v2/02_model_overview/api-description.md
@@ -4,7 +4,7 @@ title : 'Get model overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/02_model_overview/api-parameters.md
+++ b/api-documentation/editorial/articles/v2/02_model_overview/api-parameters.md
@@ -4,7 +4,7 @@ title : 'Get model overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/02_model_overview/api-request.md
+++ b/api-documentation/editorial/articles/v2/02_model_overview/api-request.md
@@ -4,7 +4,7 @@ title : 'Get model overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/02_model_overview/api-response.md
+++ b/api-documentation/editorial/articles/v2/02_model_overview/api-response.md
@@ -4,7 +4,7 @@ title : 'Get model overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/03_model_year_overview/api-description.md
+++ b/api-documentation/editorial/articles/v2/03_model_year_overview/api-description.md
@@ -4,7 +4,7 @@ title : 'Get model/year overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model/year overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/03_model_year_overview/api-parameters.md
+++ b/api-documentation/editorial/articles/v2/03_model_year_overview/api-parameters.md
@@ -4,7 +4,7 @@ title : 'Get model/year overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model/year overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/03_model_year_overview/api-request.md
+++ b/api-documentation/editorial/articles/v2/03_model_year_overview/api-request.md
@@ -4,7 +4,7 @@ title : 'Get model/year overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model/year overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/03_model_year_overview/api-response.md
+++ b/api-documentation/editorial/articles/v2/03_model_year_overview/api-response.md
@@ -4,7 +4,7 @@ title : 'Get model/year overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get model/year overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/04_road_tests_overview/api-description.md
+++ b/api-documentation/editorial/articles/v2/04_road_tests_overview/api-description.md
@@ -4,7 +4,7 @@ title : 'Get road tests overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get road tests overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/04_road_tests_overview/api-request.md
+++ b/api-documentation/editorial/articles/v2/04_road_tests_overview/api-request.md
@@ -4,7 +4,7 @@ title : 'Get road tests overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get road tests overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/04_road_tests_overview/api-response.md
+++ b/api-documentation/editorial/articles/v2/04_road_tests_overview/api-response.md
@@ -4,7 +4,7 @@ title : 'Get road tests overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 title-endpoint: 'Get road tests overview'
 spec: articles
 version: v2

--- a/api-documentation/editorial/articles/v2/index.md
+++ b/api-documentation/editorial/articles/v2/index.md
@@ -4,7 +4,7 @@ title : 'Get Edmunds Articles by Category and/or car make/model/year'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
-amount_version: 1
+amount_version: 23
 spec: articles
 version: v2
 api: editorial

--- a/api-documentation/editorial/articles/v3/03_model_year_overview/api-description.md
+++ b/api-documentation/editorial/articles/v3/03_model_year_overview/api-description.md
@@ -1,0 +1,83 @@
+---
+layout: api-documentation
+title : 'Get model/year overview'
+title_active_left_menu: 'Articles'
+title_parent: Api documentation
+
+amount_version: 23
+title-endpoint: 'Get model/year overview'
+spec: articles
+version: v3
+api: editorial
+dropdown-link: 'api/editorial/v3/{make}/{model}/{year}'
+
+
+level: 3
+description_edpoint: 'Get model/year overview'
+title_md : Description
+number: 1
+
+---
+
+
+### Description
+
+Get editorial content written by the Edmunds staff by make name, model name and year. V3 includes the current editorial review and rating format used by newer model years.
+Make sure to see the [*Special Requirements*](/api-documentation/editorial/#special_requirements) for displaying Edmunds editorial content.
+
+### URL
+
+    https://api.edmunds.com/api/editorial/v3/{make}/{model}/{year}?api_key={api_key}&fmt=json
+
+### Code Example
+
+You need the [Javascript SDK](https://github.com/EdmundsAPI/edmunds-javascript-sdk) to run this example.
+
+    <!DOCTYPE html>
+
+    <html>
+    <head>
+        <meta charset=utf-8>
+        <title>Edmunds API Example</title>
+    </head>
+
+    <body>
+        <div id="results-body"></div>
+        <script>
+              window.sdkAsyncInit = function() {
+                // Instantiate the SDK
+                var res = new EDMUNDSAPI('YOUR API KEY');
+
+                // Optional parameters
+                var options = {
+                    "view": "full"
+                };
+
+                // Callback function to be called when the API response is returned
+                function success(res) {
+                    var body = document.getElementById('results-body');
+                    body.innerHTML = "Title: " + res.title;
+                }
+
+                // Oops, Houston we have a problem!
+                function fail(data) {
+                    console.log(data);
+                }
+
+                // Fire the API call
+                res.api('/api/editorial/v3/honda/civic/2025', options, success, fail);
+
+                // Additional initialization code such as adding Event Listeners goes here
+          };
+
+          // Load the SDK asynchronously
+          (function(d, s, id){
+                 var js, sdkjs = d.getElementsByTagName(s)[0];
+                 if (d.getElementById(id)) {return;}
+                 js = d.createElement(s); js.id = id;
+                 js.src = "path/to/sdk/file";
+                 sdkjs.parentNode.insertBefore(js, sdkjs);
+           }(document, 'script', 'edmunds-jssdk'));
+        </script>
+    </body>
+    </html>

--- a/api-documentation/editorial/articles/v3/03_model_year_overview/api-parameters.md
+++ b/api-documentation/editorial/articles/v3/03_model_year_overview/api-parameters.md
@@ -1,19 +1,19 @@
 ---
 layout: api-documentation
-title : 'Get road tests overview'
+title : 'Get model/year overview'
 title_active_left_menu: 'Articles'
 title_parent: Api documentation
 
 amount_version: 23
-title-endpoint: 'Get road tests overview'
+title-endpoint: 'Get model/year overview'
 spec: articles
-version: v2
+version: v3
 api: editorial
-dropdown-link: 'api/editorial/v2/{make}/{model}/{year}/roadtests'
+dropdown-link: 'api/editorial/v3/{make}/{model}/{year}'
 
 
 level: 4
-description_edpoint: 'Get road tests overview'
+description_edpoint: 'Get model/year overview'
 title_md : Parameters
 number: 2
 

--- a/api-documentation/editorial/articles/v3/03_model_year_overview/api-request.md
+++ b/api-documentation/editorial/articles/v3/03_model_year_overview/api-request.md
@@ -1,0 +1,87 @@
+---
+layout: api-documentation
+title : 'Get model/year overview'
+title_active_left_menu: 'Articles'
+title_parent: Api documentation
+
+amount_version: 23
+title-endpoint: 'Get model/year overview'
+spec: articles
+version: v3
+api: editorial
+dropdown-link: 'api/editorial/v3/{make}/{model}/{year}'
+
+
+level: 4
+description_edpoint: 'Get model/year overview'
+title_md : Sample Request
+number: 4
+
+---
+
+### Sample Request
+
+Get Honda Civic 2025 overview.
+
+#### URL
+
+    https://api.edmunds.com/api/editorial/v3/honda/civic/2025?view=basic&api_key={API key}&fmt=json
+
+#### Response
+
+    {
+      "id": "/honda/civic/2025/review",
+      "title": "2025 Honda Civic Review",
+      "subtitle": "The quintessential small car gets a hybrid, but loses a body style",
+      "updated": "2025-02-13T00:00:00.000Z",
+      "published": "2024-06-19T00:00:00.000Z",
+      "metaDescription": "Read Edmunds' expert review of the 2025 Honda Civic.",
+      "review": {
+        "summary": {object},
+        "summarySnippet": {object},
+        "pros": {object},
+        "cons": {object},
+        "weRecommend": {object}
+      },
+      "misc": {
+        "title": "2025 Honda Civic Review",
+        "summary": {string},
+        "whatsNew": {object}
+      },
+      "rating": {
+        "driving4_0": {
+          "id": "ratings-driving4_0",
+          "title": "",
+          "summary": "",
+          "photo": [],
+          "rating": [
+            {
+              "id": "drivingExperience4_0",
+              "text": null,
+              "rating": 7.6
+            }
+          ]
+        },
+        "overall4_0": {
+          "id": "ratings-overall4_0",
+          "title": "",
+          "summary": "",
+          "photo": [],
+          "rating": [
+            {
+              "id": "overall4_0",
+              "text": null,
+              "rating": 7.9
+            }
+          ]
+        }
+      },
+      "overallRating": null,
+      "overallRatingTen": null,
+      "photos": [
+        {object},
+        ...
+      ]
+    }
+
+Rating section names vary by vehicle and editorial rating schema. For example, some vehicles return sections such as "driving4_0" and "overall4_0", while others return sections such as "driving", "comfort", "tech" and "value".

--- a/api-documentation/editorial/articles/v3/03_model_year_overview/api-response.md
+++ b/api-documentation/editorial/articles/v3/03_model_year_overview/api-response.md
@@ -1,0 +1,98 @@
+---
+layout: api-documentation
+title : 'Get model/year overview'
+title_active_left_menu: 'Articles'
+title_parent: Api documentation
+
+amount_version: 23
+title-endpoint: 'Get model/year overview'
+spec: articles
+version: v3
+api: editorial
+dropdown-link: 'api/editorial/v3/{make}/{model}/{year}'
+
+
+level: 4
+description_edpoint: 'Get model/year overview'
+title_md : Response format
+number: 3
+
+---
+
+
+### Response format
+
+#### JSON Response
+
+    {
+      "id": {string},
+      "title": {string},
+      "subtitle": {string},
+      "updated": {string},
+      "published": {string},
+      "metaDescription": {string},
+      "review": {
+        "summary": {object},
+        "summarySnippet": {object},
+        "pros": {object},
+        "cons": {object},
+        "trimTested": {object},
+        "trimFeatures": {object},
+        "trimFeaturesSnippet": {object},
+        "ltrtLink": {object},
+        "ltrtText": {object},
+        "authorPath": {object},
+        "weRecommend": {object},
+        "weRecommendSnippet": {object}
+      },
+      "misc": {
+        "id": {string},
+        "title": {string},
+        "summary": {string},
+        "safetyFeatures": {object},
+        "promoBlurb": {object},
+        "calloutQuote": {object},
+        "whatsNew": {object}
+      },
+      "rating": {
+        "{ratingSection}": {
+          "id": {string},
+          "title": {string},
+          "summary": {string},
+          "photo": [
+            {object},
+            ...
+          ],
+          "rating": [
+            {
+              "id": {string},
+              "text": {string},
+              "rating": {number}
+            },
+            ...
+          ]
+        },
+        ...
+      },
+      "overallRating": {number|null},
+      "overallRatingTen": {number|null},
+      "photos": [
+        {object},
+        ...
+      ]
+    }
+
+| Property                      | Description                                               | Visibility                |
+|:------------------------------|:----------------------------------------------------------|:--------------------------|
+| id                            | The editorial content identifier                          | Edmunds, Partners, public |
+| title                         | The editorial review title                                | Edmunds, Partners, public |
+| subtitle                      | The editorial review subtitle                             | Edmunds, Partners, public |
+| updated                       | The last updated date                                     | Edmunds, Partners, public |
+| published                     | The published date                                        | Edmunds, Partners, public |
+| metaDescription               | The editorial review summary                              | Edmunds, Partners, public |
+| review                        | The editorial review content sections, including summary, pros, cons and recommendations | Edmunds, Partners, public |
+| misc                          | Additional editorial content sections, including safety features, promo blurb, callout quote and what's new | Edmunds, Partners, public |
+| rating                        | The current editorial rating object. Rating section names vary by vehicle and editorial rating schema. | Edmunds, Partners, public |
+| overallRating                 | The overall rating value, when available                  | Edmunds, Partners, public |
+| overallRatingTen              | The overall rating on a ten-point scale, when available   | Edmunds, Partners, public |
+| photos                        | The editorial review photos                               | Edmunds, Partners, public |

--- a/api-documentation/editorial/articles/v3/index.md
+++ b/api-documentation/editorial/articles/v3/index.md
@@ -1,0 +1,27 @@
+---
+layout: api-documentation
+title : 'Get Edmunds Articles by car make/model/year'
+title_active_left_menu: 'Articles'
+title_parent: Api documentation
+
+amount_version: 23
+spec: articles
+version: v3
+api: editorial
+dropdown-link: 'Select an Endpoint'
+
+
+level: 2
+overview: page_version
+---
+
+
+<div class="info-message">
+	Get editorial content written by the Edmunds staff by the vehicle's make/model/year.
+</div>
+
+Make sure to see the [*Special Requirements*](/api-documentation/editorial/#special_requirements) for displaying Edmunds editorial content.
+
+### Endpoint
+
+* [Get model/year overview](/api-documentation/editorial/articles/v3/03_model_year_overview/api-description.html)

--- a/api-documentation/editorial/index.md
+++ b/api-documentation/editorial/index.md
@@ -39,6 +39,10 @@ Let's get right to it, shall we? Here's a few REST calls that should get you sta
 
 > https://api.edmunds.com/api/editorial/v3/makes/honda/models/civic/years/2020/expertcontent?api_key={API key}
 
+#### Example 2: Get the *Edmunds model/year overview* of the ***Honda Civic 2025***
+
+> https://api.edmunds.com/api/editorial/v3/honda/civic/2025?api_key={API key}
+
 <a name='sec-3'> </a>
 
 [Back to top](#top)
@@ -72,6 +76,7 @@ The Editorial API has three resources:
 | Resource Name                                                     | Description                                                                                                                   |
 |:------------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------|
 | [Articles](/api-documentation/editorial/articles/v2/)             | Articles written by the Edmunds staff. These can be found either by article category and/or by the vehicle's make/model/year. |
+| [Articles V3](/api-documentation/editorial/articles/v3/)          | Current editorial review and rating content by the vehicle's make/model/year.                                                 |
 | [Expert Content](/api-documentation/editorial/expert_content/v3/) | Get expert content for make/model/year.                                                                                       |
 
 <a name='sec-5'> </a>
@@ -108,6 +113,7 @@ The Editorial API has three resources:
 
 * Get all articles for a specific make/model/year
 * Get all articles for a specific make/model/year **and** specific category
+* Get current editorial review and rating content for a specific make/model/year
 * Get the Expert content of a specific make/model/year
 
 [Back to top](#top)


### PR DESCRIPTION
## Summary
- Add Editorial Articles V3 documentation for `/api/editorial/v3/{make}/{model}/{year}`
- Update Editorial Articles version tabs so V2 and V3 are both available
- Point the Editorial API overview and left nav to the V3 Articles docs

## Validation
- `git diff --check`
- Parsed frontmatter YAML for new V3 docs
- Could not run full `jekyll build`: local `jekyll` executable is not installed and this repo has no Gemfile for `bundle exec`