### PR TITLE
CP-1577 Document Editorial V3 submodel parameter

### DIFF
--- a/api-documentation/editorial/articles/v3/03_model_year_overview/api-description.md
+++ b/api-documentation/editorial/articles/v3/03_model_year_overview/api-description.md
@@ -23,6 +23,7 @@ number: 1
 ### Description
 
 Get editorial content written by the Edmunds staff by make name, model name and year. V3 includes the current editorial review and rating format used by newer model years.
+Pass the submodel nice ID when you need editorial content and ratings for a specific vehicle submodel. Submodel values vary by model year and can identify body styles or named variants, such as `sedan`, `hatchback`, `si` or `type-r`.
 Make sure to see the [*Special Requirements*](/api-documentation/editorial/#special_requirements) for displaying Edmunds editorial content.
 
 ### URL
@@ -50,7 +51,8 @@ You need the [Javascript SDK](https://github.com/EdmundsAPI/edmunds-javascript-s
 
                 // Optional parameters
                 var options = {
-                    "view": "full"
+                    "view": "full",
+                    "submodel": "sedan"
                 };
 
                 // Callback function to be called when the API response is returned

--- a/api-documentation/editorial/articles/v3/03_model_year_overview/api-parameters.md
+++ b/api-documentation/editorial/articles/v3/03_model_year_overview/api-parameters.md
@@ -28,5 +28,6 @@ number: 2
 | {model}       | The car model                         | See [Spec: Model](/api-documentation/vehicle/spec_model/v3/) |            | Yes                   |
 | {year}        | The car year                          | See [Spec: Year](/api-documentation/vehicle/spec_model_year/v3/) |              | Yes                   |
 | view          | Response detail level                 | basic, full           | basic         | No                                                        |
+| submodel      | Submodel nice ID used to filter the editorial content and ratings | Examples vary by model year and can include sedan, hatchback, si, type-r |       | No                                                        |
 | fmt           | Response format                       | json                  | json          | Yes                                                       |
 | api_key       | Your Edmunds/Editorial API key        |                       |               | Yes                                                       |


### PR DESCRIPTION
Adds the optional submodel query parameter to the Editorial Articles V3 model/year overview documentation and sample request.